### PR TITLE
jessie-backports has been archived

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM golang:1.8
+FROM golang:1.12-stretch
 MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
 
 ENV PG_MAJOR 9.6
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \
- && echo 'deb http://httpredir.debian.org/debian jessie-backports main contrib' > /etc/apt/sources.list.d/backports.list \
- && DEBIAN_FRONTEND=noninteractive apt-get update \
- # install newer packages from backports 
- && DEBIAN_FRONTEND=noninteractive apt-get  -t jessie-backports install -y --no-install-recommends \
+ENV DEBIAN_FRONTEND noninteractive
+
+# work around apt-key error when running in Docker
+RUN mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+ && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
+ && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
       libgeos-dev \
       libleveldb-dev \
       libprotobuf-dev \
@@ -16,7 +18,6 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A4
  # install postgresql client
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       postgresql-client-$PG_MAJOR \
- && ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so \
  && rm -rf /var/lib/apt/lists/*
 
  # add  github.com/julien-noblet/download-geofabrik


### PR DESCRIPTION
Per https://www.lucas-nussbaum.net/blog/?p=947

Using the archived package repository was still causing problems, so this updates to a golang image based on Debian stretch and applies relevant tweaks.